### PR TITLE
Move rockets on a non linear path

### DIFF
--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -17,7 +17,7 @@ use crate::world::Rematch;
 use crate::RollbackState;
 
 // Movement
-pub const MIN_SPEED: f32 = 200.0 / 60.0;
+pub const MIN_SPEED: f32 = 000.0 / 60.0;
 pub const DELTA_SPEED: f32 = 75.0 / 60.0 / 100.0;
 pub const DELTA_STEERING: f32 = 3.5 / 60.0;
 // Collision


### PR DESCRIPTION
This is NOT desync proof and I am mostl likely only going to leave this as a reference point.

See https://github.com/PraxTube/ace-of-the-heavens/blob/add-curved-rocket-path/docs/demo/rocket-random-curve.gif.
